### PR TITLE
feat: Quick Add to Cart from product listing page

### DIFF
--- a/src/modules/products/components/product-preview/index.tsx
+++ b/src/modules/products/components/product-preview/index.tsx
@@ -1,32 +1,27 @@
 import { Text } from "@medusajs/ui"
-import { listProducts } from "@lib/data/products"
 import { getProductPrice } from "@lib/util/get-product-price"
 import { HttpTypes } from "@medusajs/types"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
 import Thumbnail from "../thumbnail"
 import PreviewPrice from "./price"
+import QuickAddButton from "../quick-add-button"
 
 export default async function ProductPreview({
   product,
   isFeatured,
   region,
+  countryCode,
 }: {
   product: HttpTypes.StoreProduct
   isFeatured?: boolean
   region: HttpTypes.StoreRegion
+  countryCode?: string
 }) {
-  // const pricedProduct = await listProducts({
-  //   regionId: region.id,
-  //   queryParams: { id: [product.id!] },
-  // }).then(({ response }) => response.products[0])
-
-  // if (!pricedProduct) {
-  //   return null
-  // }
-
   const { cheapestPrice } = getProductPrice({
     product,
   })
+
+  const firstVariant = product.variants?.[0]
 
   return (
     <LocalizedClientLink href={`/products/${product.handle}`} className="group">
@@ -45,6 +40,14 @@ export default async function ProductPreview({
             {cheapestPrice && <PreviewPrice price={cheapestPrice} />}
           </div>
         </div>
+        {firstVariant && countryCode && (
+          <div className="mt-2">
+            <QuickAddButton
+              variantId={firstVariant.id}
+              countryCode={countryCode}
+            />
+          </div>
+        )}
       </div>
     </LocalizedClientLink>
   )

--- a/src/modules/products/components/quick-add-button/index.tsx
+++ b/src/modules/products/components/quick-add-button/index.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import { useState } from "react"
+import { addToCart } from "@lib/data/cart"
+
+type QuickAddButtonProps = {
+  variantId: string
+  countryCode: string
+}
+
+const QuickAddButton = ({ variantId, countryCode }: QuickAddButtonProps) => {
+  const [status, setStatus] = useState<
+    "idle" | "loading" | "added" | "failed"
+  >("idle")
+
+  const handleAddToCart = async (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+
+    if (status === "loading") return
+
+    setStatus("loading")
+
+    try {
+      await addToCart({
+        variantId,
+        quantity: 1,
+        countryCode,
+      })
+      setStatus("added")
+      setTimeout(() => setStatus("idle"), 2000)
+    } catch {
+      setStatus("failed")
+      setTimeout(() => setStatus("idle"), 2000)
+    }
+  }
+
+  const label = {
+    idle: "Add to Cart",
+    loading: "Adding...",
+    added: "Added!",
+    failed: "Failed",
+  }[status]
+
+  return (
+    <button
+      type="button"
+      onClick={handleAddToCart}
+      disabled={status === "loading"}
+      data-testid="quick-add-button"
+      className={`
+        w-full py-2 text-xs font-medium tracking-wide uppercase transition-all duration-200
+        ${status === "added"
+          ? "bg-green-600 text-white"
+          : status === "failed"
+            ? "bg-red-500 text-white"
+            : "bg-grey-90 text-white hover:bg-grey-80"
+        }
+        ${status === "loading" ? "opacity-60 cursor-wait" : ""}
+        opacity-0 group-hover:opacity-100 small:opacity-0 small:group-hover:opacity-100
+        max-[1023px]:opacity-100
+      `}
+    >
+      {label}
+    </button>
+  )
+}
+
+export default QuickAddButton

--- a/src/modules/store/templates/paginated-products.tsx
+++ b/src/modules/store/templates/paginated-products.tsx
@@ -81,7 +81,7 @@ export default async function PaginatedProducts({
         {products.map((p) => {
           return (
             <li key={p.id}>
-              <ProductPreview product={p} region={region} />
+              <ProductPreview product={p} region={region} countryCode={countryCode} />
             </li>
           )
         })}


### PR DESCRIPTION
## Summary

Closes #3

Adds an "Add to Cart" button directly on product cards in the store listing page, allowing users to add items without visiting the product detail page.

## Files Changed

- **New:** `src/modules/products/components/quick-add-button/index.tsx` — Client component with loading/success/error states
- **Modified:** `src/modules/products/components/product-preview/index.tsx` — Added QuickAddButton + countryCode prop
- **Modified:** `src/modules/store/templates/paginated-products.tsx` — Pass countryCode to ProductPreview

## Behavior

| State | Button Text | Color | Duration |
|---|---|---|---|
| Idle | Add to Cart | Dark (grey-90) | — |
| Loading | Adding... | Grey (opacity) | While API call |
| Success | Added! | Green | 2 seconds |
| Error | Failed | Red | 2 seconds |

## Test Plan

- [ ] Button visible on product cards in /store on hover (desktop)
- [ ] Button always visible on mobile
- [ ] Click adds first variant to cart
- [ ] Cart count in nav updates immediately
- [ ] Shows "Added!" confirmation for 2 seconds
- [ ] Shows loading state during API call
- [ ] data-testid="quick-add-button" present for automation

## Related
- QA Issue: Anasss/qa-automation#2